### PR TITLE
Bug in AbstractContentElement.php

### DIFF
--- a/src/Component/ContentElement/AbstractContentElement.php
+++ b/src/Component/ContentElement/AbstractContentElement.php
@@ -46,7 +46,7 @@ abstract class AbstractContentElement extends AbstractComponent implements Conte
             return true;
         }
 
-        if (!$this->get('invisible')) {
+        if ($this->get('invisible')) {
             return false;
         }
 


### PR DESCRIPTION
I found a bug in AbstractContentElement.php that causes a disappearing of all grid elements in the contao-bootstrap/grid extension when I set hidden elements in the contao preview to visible. 