### PR TITLE
Fix visibility check for content elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 [Unreleased]
 ------------
 
+### Changed
+
+ - Do not depend on constant TL_MODE to detect request scope. Use `RequestScopeMatcher` instead for components. Not
+   passing `RequestScopeMatcher` as constructor argument to components (content elements, modules) is deprecated now.
+ - Do not detect preview mode using BE_USER_LOGGED_IN constant. State has to be passed to the constructor for content 
+   elements. Deprecate not passing the `isPreviewMode` state as constructor argument.
+
 [3.3.0] (2019-04-09)
 --------------------
 

--- a/spec/Component/ContentElement/AbstractContentElementSpec.php
+++ b/spec/Component/ContentElement/AbstractContentElementSpec.php
@@ -13,9 +13,13 @@
 namespace spec\Netzmacht\Contao\Toolkit\Component\ContentElement;
 
 use Netzmacht\Contao\Toolkit\Component\ContentElement\AbstractContentElement;
+use Netzmacht\Contao\Toolkit\Routing\RequestScopeMatcher;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Templating\EngineInterface;
+use Netzmacht\Contao\Toolkit\Component\Component;
+use Netzmacht\Contao\Toolkit\Component\ContentElement\ContentElement;
+use function time;
 
 if (!defined('BE_USER_LOGGED_IN')) {
     define('BE_USER_LOGGED_IN', false);
@@ -33,7 +37,7 @@ class AbstractContentElementSpec extends ObjectBehavior
 
     private $modelData;
 
-    function let(EngineInterface $templateEngine)
+    function let(EngineInterface $templateEngine, RequestScopeMatcher $requestScopeMatcher)
     {
         $this->modelData = [
             'type' => 'test',
@@ -44,27 +48,104 @@ class AbstractContentElementSpec extends ObjectBehavior
 
         $this->model = new Model($this->modelData);
 
-        $this->beAnInstanceOf('spec\Netzmacht\Contao\Toolkit\Component\ContentElement\ConcreteContentElement');
-        $this->beConstructedWith($this->model, $templateEngine);
+        $requestScopeMatcher->isFrontendRequest()->willReturn(true);
+
+        $this->beAnInstanceOf(ConcreteContentElement::class);
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher);
     }
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Netzmacht\Contao\Toolkit\Component\ContentElement\AbstractContentElement');
+        $this->shouldHaveType(AbstractContentElement::class);
     }
 
     function it_is_a_component()
     {
-        $this->shouldImplement('Netzmacht\Contao\Toolkit\Component\Component');
+        $this->shouldImplement(Component::class);
     }
 
     function it_is_a_content_element()
     {
-        $this->shouldImplement('Netzmacht\Contao\Toolkit\Component\ContentElement\ContentElement');
+        $this->shouldImplement(ContentElement::class);
     }
 
     function it_generates_output(EngineInterface $templateEngine)
     {
+        $templateEngine->render(Argument::cetera())->willReturn('output');
+
+        $this->generate()->shouldBeString();
+        $this->generate()->shouldReturn('output');
+    }
+
+    function it_doesnt_generate_output_if_invisible(
+        EngineInterface $templateEngine,
+        RequestScopeMatcher $requestScopeMatcher
+    ) {
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher);
+
+        $this->model->invisible = true;
+
+        $templateEngine->render(Argument::cetera())->shouldNotBeCalled();
+
+        $this->generate()->shouldBeString();
+        $this->generate()->shouldReturn('');
+    }
+
+    function it_doesnt_generate_output_if_starts_in_future(
+        EngineInterface $templateEngine,
+        RequestScopeMatcher $requestScopeMatcher
+    ) {
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher);
+
+        $this->model->start = time() + 3600;
+
+        $templateEngine->render(Argument::cetera())->shouldNotBeCalled();
+
+        $this->generate()->shouldBeString();
+        $this->generate()->shouldReturn('');
+    }
+
+    function it_doesnt_generate_output_if_stopped_in_past(
+        EngineInterface $templateEngine,
+        RequestScopeMatcher $requestScopeMatcher
+    ) {
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher);
+
+        $this->model->start = time() - 3600;
+        $this->model->stop = time() - 3600;
+
+        $templateEngine->render(Argument::cetera())->shouldNotBeCalled();
+
+        $this->generate()->shouldBeString();
+        $this->generate()->shouldReturn('');
+    }
+
+    function it_ignores_visibility_settings_on_non_frontend_request(
+        EngineInterface $templateEngine,
+        RequestScopeMatcher $requestScopeMatcher
+    ) {
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher);
+
+        $requestScopeMatcher->isFrontendRequest()->willReturn(false);
+
+        $this->model->invisible = true;
+
+        $templateEngine->render(Argument::cetera())->willReturn('output');
+
+        $this->generate()->shouldBeString();
+        $this->generate()->shouldReturn('output');
+    }
+
+    function it_ignores_visibility_settings_on_preview_mode(
+        EngineInterface $templateEngine,
+        RequestScopeMatcher $requestScopeMatcher
+    ) {
+        $this->beConstructedWith($this->model, $templateEngine, 'main', $requestScopeMatcher, true);
+
+        $requestScopeMatcher->isFrontendRequest()->willReturn(true);
+
+        $this->model->invisible = true;
+
         $templateEngine->render(Argument::cetera())->willReturn('output');
 
         $this->generate()->shouldBeString();

--- a/src/Component/AbstractComponent.php
+++ b/src/Component/AbstractComponent.php
@@ -20,9 +20,13 @@ use Contao\Model\Collection;
 use Contao\StringUtil;
 use InvalidArgumentException;
 use Netzmacht\Contao\Toolkit\Assertion\Assertion;
+use Netzmacht\Contao\Toolkit\Routing\RequestScopeMatcher;
 use Netzmacht\Contao\Toolkit\View\Template\TemplateReference as ToolkitTemplateReference;
 use Symfony\Component\Templating\EngineInterface as TemplateEngine;
 use Symfony\Component\Templating\TemplateReferenceInterface as TemplateReference;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+use const TL_MODE;
 
 /**
  * Base element.
@@ -67,16 +71,28 @@ abstract class AbstractComponent implements Component
     private $templateEngine;
 
     /**
+     * Request scope matcher.
+     *
+     * @var RequestScopeMatcher|null
+     */
+    protected $requestScopeMatcher;
+
+    /**
      * AbstractContentElement constructor.
      *
-     * @param Model|Collection|Result $model          Object model or result.
-     * @param TemplateEngine          $templateEngine Template engine.
-     * @param string                  $column         Column.
+     * @param Model|Collection|Result  $model               Object model or result.
+     * @param TemplateEngine           $templateEngine      Template engine.
+     * @param string                   $column              Column.
+     * @param RequestScopeMatcher|null $requestScopeMatcher Request scope matcher.
      *
      * @throws InvalidArgumentException When model does not have a row method.
      */
-    public function __construct($model, TemplateEngine $templateEngine, $column = 'main')
-    {
+    public function __construct(
+        $model,
+        TemplateEngine $templateEngine,
+        $column = 'main',
+        ?RequestScopeMatcher $requestScopeMatcher = null
+    ) {
         if ($model instanceof Collection) {
             $model = $model->current();
         }
@@ -85,13 +101,23 @@ abstract class AbstractComponent implements Component
             $this->model = $model;
         }
 
+        if ($requestScopeMatcher === null) {
+            // @codingStandardsIgnoreStart
+            @trigger_error(
+                'RequestScopeMatcher not passed as forth argument. RequestScopeMatcher will be required in version 4.0.0',
+                E_USER_DEPRECATED
+            );
+            // @codingStandardsIgnoreEnd
+        }
+
         Assertion::methodExists('row', $model);
 
-        $this->templateEngine = $templateEngine;
-        $this->column         = $column;
-        $this->data           = $this->deserializeData($model->row());
+        $this->templateEngine      = $templateEngine;
+        $this->column              = $column;
+        $this->requestScopeMatcher = $requestScopeMatcher;
+        $this->data                = $this->deserializeData($model->row());
 
-        if ($this->get('customTpl') != '' && TL_MODE == 'FE') {
+        if ($this->get('customTpl') !== '' && $this->isFrontendRequest()) {
             $this->setTemplateName((string) $this->get('customTpl'));
         }
     }
@@ -324,5 +350,33 @@ abstract class AbstractComponent implements Component
             'html5',
             ToolkitTemplateReference::SCOPE_FRONTEND
         );
+    }
+
+    /**
+     * Check if current request is a Contao frontend request.
+     *
+     * @return bool
+     */
+    protected function isFrontendRequest(): bool
+    {
+        if ($this->requestScopeMatcher) {
+            return $this->requestScopeMatcher->isFrontendRequest();
+        }
+
+        return TL_MODE === 'FE';
+    }
+
+    /**
+     * Check if current request is a Contao backend request.
+     *
+     * @return bool
+     */
+    protected function isBackendRequest(): bool
+    {
+        if ($this->requestScopeMatcher) {
+            return $this->requestScopeMatcher->isBackendRequest();
+        }
+
+        return TL_MODE === 'BE';
     }
 }

--- a/src/Component/ContentElement/AbstractContentElement.php
+++ b/src/Component/ContentElement/AbstractContentElement.php
@@ -5,6 +5,7 @@
  *
  * @package    contao-toolkit
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Dennis Bohn <dennis.bohn@bohn.media>
  * @copyright  2015-2018 netzmacht David Molineus.
  * @license    LGPL-3.0-or-later https://github.com/netzmacht/contao-toolkit/blob/master/LICENSE
  * @filesource

--- a/src/Component/ContentElement/AbstractContentElement.php
+++ b/src/Component/ContentElement/AbstractContentElement.php
@@ -14,7 +14,16 @@ declare(strict_types=1);
 
 namespace Netzmacht\Contao\Toolkit\Component\ContentElement;
 
+use Contao\Database\Result;
+use Contao\Model;
+use Contao\Model\Collection;
+use InvalidArgumentException;
 use Netzmacht\Contao\Toolkit\Component\AbstractComponent;
+use Netzmacht\Contao\Toolkit\Routing\RequestScopeMatcher;
+use Symfony\Component\Templating\EngineInterface as TemplateEngine;
+use function trigger_error;
+use const BE_USER_LOGGED_IN;
+use const E_USER_DEPRECATED;
 
 /**
  * Class AbstractContentElement.
@@ -23,6 +32,47 @@ use Netzmacht\Contao\Toolkit\Component\AbstractComponent;
  */
 abstract class AbstractContentElement extends AbstractComponent implements ContentElement
 {
+    /**
+     * State if the request is called in the preview mode.
+     *
+     * @var bool|null
+     */
+    private $isPreviewMode;
+
+    /**
+     * AbstractContentElement constructor.
+     *
+     * @param Model|Collection|Result  $model               Object model or result.
+     * @param TemplateEngine           $templateEngine      Template engine.
+     * @param string                   $column              Column.
+     * @param RequestScopeMatcher|null $requestScopeMatcher Request scope matcher.
+     * @param bool|null                $isPreviewMode       State if the request is called in the preview mode.
+     *
+     * @throws InvalidArgumentException When model does not have a row method.
+     */
+    public function __construct(
+        $model,
+        TemplateEngine $templateEngine,
+        $column = 'main',
+        ?RequestScopeMatcher $requestScopeMatcher = null,
+        ?bool $isPreviewMode = null
+    ) {
+        parent::__construct($model, $templateEngine, $column, $requestScopeMatcher);
+
+        if ($isPreviewMode === null) {
+            // @codingStandardsIgnoreStart
+            @trigger_error(
+                'isPreviewMode not passed as fifth argument. isPreviewMode will be required in version 4.0.0',
+                E_USER_DEPRECATED
+            );
+            // @codingStandardsIgnoreEnd
+
+            $isPreviewMode = BE_USER_LOGGED_IN;
+        }
+
+        $this->isPreviewMode = $isPreviewMode;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -42,7 +92,7 @@ abstract class AbstractContentElement extends AbstractComponent implements Conte
      */
     protected function isVisible(): bool
     {
-        if (TL_MODE !== 'FE' || BE_USER_LOGGED_IN) {
+        if ($this->isPreviewMode || !$this->isFrontendRequest()) {
             return true;
         }
 

--- a/src/Component/ContentElement/AbstractContentElement.php
+++ b/src/Component/ContentElement/AbstractContentElement.php
@@ -42,7 +42,7 @@ abstract class AbstractContentElement extends AbstractComponent implements Conte
      */
     protected function isVisible(): bool
     {
-        if (TL_MODE === 'FE' && BE_USER_LOGGED_IN) {
+        if (TL_MODE !== 'FE' || BE_USER_LOGGED_IN) {
             return true;
         }
 

--- a/src/Component/ContentElement/AbstractContentElement.php
+++ b/src/Component/ContentElement/AbstractContentElement.php
@@ -42,11 +42,11 @@ abstract class AbstractContentElement extends AbstractComponent implements Conte
      */
     protected function isVisible(): bool
     {
-        if (TL_MODE !== 'FE' || !BE_USER_LOGGED_IN) {
+        if (TL_MODE === 'FE' && BE_USER_LOGGED_IN) {
             return true;
         }
 
-        if (!$this->get('invisible')) {
+        if ($this->get('invisible')) {
             return false;
         }
 

--- a/src/Component/Module/AbstractModule.php
+++ b/src/Component/Module/AbstractModule.php
@@ -18,6 +18,7 @@ use Contao\Database\Result;
 use Contao\Model;
 use Contao\Model\Collection;
 use Netzmacht\Contao\Toolkit\Component\AbstractComponent;
+use Netzmacht\Contao\Toolkit\Routing\RequestScopeMatcher;
 use Symfony\Component\Templating\EngineInterface as TemplateEngine;
 use Symfony\Component\Translation\TranslatorInterface as Translator;
 
@@ -45,14 +46,20 @@ abstract class AbstractModule extends AbstractComponent implements Module
     /**
      * AbstractModule constructor.
      *
-     * @param Model|Collection|Result $model          Object model or result.
-     * @param TemplateEngine          $templateEngine Template engine.
-     * @param Translator              $translator     Translator.
-     * @param string                  $column         Column.
+     * @param Model|Collection|Result  $model               Object model or result.
+     * @param TemplateEngine           $templateEngine      Template engine.
+     * @param Translator               $translator          Translator.
+     * @param string                   $column              Column.
+     * @param RequestScopeMatcher|null $requestScopeMatcher Request scope matcher.
      */
-    public function __construct($model, TemplateEngine $templateEngine, Translator $translator, $column = 'main')
-    {
-        parent::__construct($model, $templateEngine, $column);
+    public function __construct(
+        $model,
+        TemplateEngine $templateEngine,
+        Translator $translator,
+        $column = 'main',
+        ?RequestScopeMatcher $requestScopeMatcher = null
+    ) {
+        parent::__construct($model, $templateEngine, $column, $requestScopeMatcher);
 
         $this->translator = $translator;
     }
@@ -62,7 +69,7 @@ abstract class AbstractModule extends AbstractComponent implements Module
      */
     public function generate(): string
     {
-        if (TL_MODE === 'BE' && !$this->renderInBackendMode) {
+        if (!$this->renderInBackendMode && $this->isBackendRequest()) {
             return $this->generateBackendView();
         }
 


### PR DESCRIPTION
This PR is the follow up solution for #22. It fixes the visibility issues of the content element component. 

To test the implementation I did some refactoring of `AbstractComponent`, `AbstractModule` and `AbstractContentElement` not relying on the global constants `TL_MODE` and `BE_USER_LOGGED_IN` anymore. Because of new introduced deprecations the fix will be part of the next minor release.