### PR TITLE
Make sure cssID array has always two elements

### DIFF
--- a/src/Controller/AbstractFragmentController.php
+++ b/src/Controller/AbstractFragmentController.php
@@ -128,7 +128,7 @@ abstract class AbstractFragmentController implements FragmentOptionsAwareInterfa
     private function prepareDefaultTemplateData(Model $model, string $section, ?array $classes = null): array
     {
         $data    = $model->row();
-        $cssID   = StringUtil::deserialize($data['cssID'], true);
+        $cssID   = StringUtil::deserialize($data['cssID'], true) + ['', ''];
         $classes = $classes ?: [];
 
         if ($cssID[1] !== '') {


### PR DESCRIPTION
If the `cssID` property of a content element is empty (i.e. an empty array), currently thee controller will always out an empty `id` attribute in the front end. For example in `contao-bootstrap/grid`:

```html
<div  id="" class="ce_bs_gridSeparator col-sm-12 col-lg-6">
```

This is because `$cssID[0]` and `$cssID[1]` will return `null` in such a case and thus the check `$cssID[0] !== ''` will be true: 
https://github.com/netzmacht/contao-toolkit/blob/2931ccd84776bd06fef3a376364ee06ac2fe30db/src/Controller/AbstractFragmentController.php#L139

This PR fixes that by making sure that the `$cssID` variable will always have at least two elements with empty strings. This would also fix any warnings under PHP 8.