### PR TITLE
Remove dev tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "type": "contao-bundle",
   "keywords": [
     "contao",
-    "dev",
     "tools"
   ],
   "authors": [


### PR DESCRIPTION
Due to https://github.com/composer/composer/pull/10960 - I think it'd be good to remove the dev tag here unless you would recommend everyone puts this package in require-dev?