### PR TITLE
Fix implicitly nullable marking

### DIFF
--- a/src/View/Template/TemplateFactory.php
+++ b/src/View/Template/TemplateFactory.php
@@ -22,7 +22,7 @@ interface TemplateFactory
      */
     public function createFrontendTemplate(
         string $name,
-        array $data = null,
+        ?array $data = null,
         string $contentType = 'text/html',
     ): Template;
 
@@ -35,7 +35,7 @@ interface TemplateFactory
      */
     public function createBackendTemplate(
         string $name,
-        array $data = null,
+        ?array $data = null,
         string $contentType = 'text/html',
     ): Template;
 }


### PR DESCRIPTION
This PR fix two " Implicitly marking parameter $data as nullable is deprecated"  warnings.